### PR TITLE
fixing eoi issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,9 @@ class Pipe2Jpeg extends Transform {
     super(options);
     this._chunks = [];
     this._size = 0;
-    this._increment = options?.increment ?? 250;
+
+    this._lastSize = 0;
+    this._lastByte = null;
   }
 
   /**
@@ -66,10 +68,20 @@ class Pipe2Jpeg extends Transform {
    * @private
    */
   _transform(chunk, encoding, callback) {
-    const chunkLength = chunk.length;
+    let chunkLength = chunk.length;
     let pos = 0;
     while (true) {
       if (this._size) {
+        const lastChunk = this._chunks[this._chunks.length - 1];
+        const lastByte = lastChunk[lastChunk.length - 1];
+        if (lastByte === _EOI[0] && chunk[0] === _EOI[1]) {
+          // EOI was split across chunks, remove it from the previous chunk and add it to this one
+          this._chunks[this._chunks.length - 1] = lastChunk.slice(0, lastChunk.length - 1);
+          this._size -= 1;
+          const startByte = Buffer.from([_EOI[0]]);
+          chunk = Buffer.concat([startByte, chunk]);
+          chunkLength += 1;
+        }
         const eoi = chunk.indexOf(_EOI);
         if (eoi === -1) {
           this._chunks.push(chunk);
@@ -82,6 +94,7 @@ class Pipe2Jpeg extends Transform {
           this._size += sliced.length;
           this._jpeg = Buffer.concat(this._chunks, this._size);
           this._chunks = [];
+          this._lastSize = this._size;
           this._size = 0;
           this._sendJpeg();
           if (pos === chunkLength) {
@@ -89,11 +102,22 @@ class Pipe2Jpeg extends Transform {
           }
         }
       } else {
+        if (this._lastByte === _SOI[0] && chunk[0] === _SOI[1]) {
+          // SOI was split across chunks
+          const startByte = Buffer.from([_SOI[0]]);
+          chunk = Buffer.concat([startByte, chunk]);
+          chunkLength += 1;
+          pos = Math.max(pos - 1, 0);
+        }
         const soi = chunk.indexOf(_SOI, pos);
         if (soi === -1) {
+          // save the last byte in case the soi is broken across chunks
+          this._lastByte = chunk[chunkLength - 1];
           break;
         } else {
-          pos = soi + this._increment;
+          // as an optimization, jump forward half of the previous jpeg size
+          const stepForward = this._lastSize / 2;
+          pos = soi + stepForward;
         }
         const eoi = chunk.indexOf(_EOI, pos);
         if (eoi === -1) {
@@ -104,6 +128,7 @@ class Pipe2Jpeg extends Transform {
         } else {
           pos = eoi + 2;
           this._jpeg = chunk.slice(soi, pos);
+          this._lastSize = this._jpeg.length;
           this._sendJpeg();
           if (pos === chunkLength) {
             break;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lumen5-pipe2jpeg",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Parse individual jpegs from an ffmpeg pipe when output codec is set to mjpeg and format is set to image2pipe, singlejpeg, mjpeg, or mpjeg.",
   "main": "index.js",
   "dependencies": {},


### PR DESCRIPTION
This addresses two issue:
1. Smarter forward seeking when looking for end of input (EOI) after receiving the start of input (SOI). Before it was just a fixed offset, which could cause issues if the forward skip missed the next EOI. The new approach uses half of the size of the last received jpeg (so the assumption here is that the input frames won't be widely different sizes, which I think is reasonable).
2. I had an edge case where ffmpeg split the EOI across two chunks. So the last byte of the previous chunk had the first byte of EOI and the next chunk started with the second byte of EOI. I've updated the logic to handle this case, and also the related case of where the SOI could be split (but that case was not something I've come across yet). 