### PR TITLE
Allow pause/resume in pipe2jpeg stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,7 +111,12 @@ class Pipe2Jpeg extends Transform {
         }
       }
     }
-    callback();
+    if(this.isPaused()){
+      this.once("resume", callback)
+    }
+    else{
+        callback()
+    }
   }
 
   /**


### PR DESCRIPTION
Allow correct pause/resume in pipe2jpeg stream
Without this PR stream continue emitting ```jpeg``` event if stream explicitly paused. This can cause memory/cpu leaks.
