### PR TITLE
avoid jumping forward as much to not miss images

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,8 +115,9 @@ class Pipe2Jpeg extends Transform {
           this._lastByte = chunk[chunkLength - 1];
           break;
         } else {
-          // as an optimization, jump forward half of the previous jpeg size
-          const stepForward = Math.floor(this._lastJpegSize / 2);
+          // as an optimization, jump forward 1% of the previous jpeg size
+          // if this is too big we'll miss the next image!
+          const stepForward = Math.floor(this._lastJpegSize / 100);
           pos = soi + stepForward;
         }
         const eoi = chunk.indexOf(_EOI, pos);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "pipe2jpeg",
-  "version": "0.3.2",
+  "name": "lumen5-pipe2jpeg",
+  "version": "0.3.4",
   "description": "Parse individual jpegs from an ffmpeg pipe when output codec is set to mjpeg and format is set to image2pipe, singlejpeg, mjpeg, or mpjeg.",
   "main": "index.js",
   "dependencies": {},


### PR DESCRIPTION
We had some cases where we were missing images! The divide by 2 was actually way too aggressive because this is a lossy encoding. This means images can vary quite a bit in size from one to the next due to the effectiveness of the compression for a given frame.